### PR TITLE
Include $_COOKIE to $_REQUEST

### DIFF
--- a/src/MagicQuotesGpcEmulator.php
+++ b/src/MagicQuotesGpcEmulator.php
@@ -5,7 +5,6 @@ class MagicQuotesGpcEmulator {
     $_GET = filter_var_array($_GET, FILTER_SANITIZE_MAGIC_QUOTES);
     $_POST = filter_var_array($_POST, FILTER_SANITIZE_MAGIC_QUOTES);
     $_COOKIE = filter_var_array($_COOKIE, FILTER_SANITIZE_MAGIC_QUOTES);
-
-    $_REQUEST = array_merge($_GET, $_POST, $_COOKIE);
+    $_REQUEST = filter_var_array($_REQUEST, FILTER_SANITIZE_MAGIC_QUOTES);
   }
 }

--- a/src/MagicQuotesGpcEmulator.php
+++ b/src/MagicQuotesGpcEmulator.php
@@ -6,6 +6,6 @@ class MagicQuotesGpcEmulator {
     $_POST = filter_var_array($_POST, FILTER_SANITIZE_MAGIC_QUOTES);
     $_COOKIE = filter_var_array($_COOKIE, FILTER_SANITIZE_MAGIC_QUOTES);
 
-    $_REQUEST = array_merge($_GET, $_POST);
+    $_REQUEST = array_merge($_GET, $_POST, $_COOKIE);
   }
 }

--- a/tests/MagicQuotesGpcEmulatorTest.php
+++ b/tests/MagicQuotesGpcEmulatorTest.php
@@ -12,7 +12,6 @@ class MagicQuotesGpcEmulatorTest extends PHPUnit\Framework\TestCase {
         "bar" => "ba\"r",
         "baz" => "ba\z",
         "qux" => "qu" . chr(0) . "x",
-        "getOnlyValue" => "getOnlyValue",
       ];
 
       $_POST = [
@@ -20,7 +19,6 @@ class MagicQuotesGpcEmulatorTest extends PHPUnit\Framework\TestCase {
         "bar" => "ba\"r",
         "baz" => "ba\z",
         "qux" => "qu" . chr(0) . "x",
-        "postOnlyValue" => "postOnlyValue",
       ];
 
       $_COOKIE = [
@@ -28,7 +26,13 @@ class MagicQuotesGpcEmulatorTest extends PHPUnit\Framework\TestCase {
         "bar" => "ba\"r",
         "baz" => "ba\z",
         "qux" => "qu" . chr(0) . "x",
-        "cookieOnlyValue" => "cookieOnlyValue",
+      ];
+
+      $_REQUEST = [
+        "foo" => "fo'o",
+        "bar" => "ba\"r",
+        "baz" => "ba\z",
+        "qux" => "qu" . chr(0) . "x",
       ];
   }
 
@@ -45,7 +49,6 @@ class MagicQuotesGpcEmulatorTest extends PHPUnit\Framework\TestCase {
       "bar" => "ba\\\"r",
       "baz" => "ba\\\\z",
       "qux" => "qu\\0x",
-      "getOnlyValue" => "getOnlyValue",
     ];
 
     $expectPostValues = [
@@ -53,7 +56,6 @@ class MagicQuotesGpcEmulatorTest extends PHPUnit\Framework\TestCase {
       "bar" => "ba\\\"r",
       "baz" => "ba\\\\z",
       "qux" => "qu\\0x",
-      "postOnlyValue" => "postOnlyValue",
     ];
 
     $expectCookieValues = [
@@ -61,7 +63,6 @@ class MagicQuotesGpcEmulatorTest extends PHPUnit\Framework\TestCase {
       "bar" => "ba\\\"r",
       "baz" => "ba\\\\z",
       "qux" => "qu\\0x",
-      "cookieOnlyValue" => "cookieOnlyValue",
     ];
 
     $expectRequestValues = [
@@ -69,9 +70,6 @@ class MagicQuotesGpcEmulatorTest extends PHPUnit\Framework\TestCase {
       "bar" => "ba\\\"r",
       "baz" => "ba\\\\z",
       "qux" => "qu\\0x",
-      "getOnlyValue" => "getOnlyValue",
-      "postOnlyValue" => "postOnlyValue",
-      "cookieOnlyValue" => "cookieOnlyValue",
     ];
 
     $this->assertEquals($_GET, $expectGetValues);

--- a/tests/MagicQuotesGpcEmulatorTest.php
+++ b/tests/MagicQuotesGpcEmulatorTest.php
@@ -28,13 +28,7 @@ class MagicQuotesGpcEmulatorTest extends PHPUnit\Framework\TestCase {
         "bar" => "ba\"r",
         "baz" => "ba\z",
         "qux" => "qu" . chr(0) . "x",
-      ];
-
-      $_REQUEST = [
-        "foo" => "fo'o",
-        "bar" => "ba\"r",
-        "baz" => "ba\z",
-        "qux" => "qu" . chr(0) . "x",
+        "cookieOnlyValue" => "cookieOnlyValue",
       ];
   }
 
@@ -67,6 +61,7 @@ class MagicQuotesGpcEmulatorTest extends PHPUnit\Framework\TestCase {
       "bar" => "ba\\\"r",
       "baz" => "ba\\\\z",
       "qux" => "qu\\0x",
+      "cookieOnlyValue" => "cookieOnlyValue",
     ];
 
     $expectRequestValues = [
@@ -76,6 +71,7 @@ class MagicQuotesGpcEmulatorTest extends PHPUnit\Framework\TestCase {
       "qux" => "qu\\0x",
       "getOnlyValue" => "getOnlyValue",
       "postOnlyValue" => "postOnlyValue",
+      "cookieOnlyValue" => "cookieOnlyValue",
     ];
 
     $this->assertEquals($_GET, $expectGetValues);


### PR DESCRIPTION
$ _REQUEST should include $ _COOKIE

```
An associative array that by default contains the contents of $_GET, $_POST and $_COOKIE.
```

Please see below for the details:
https://www.php.net/manual/ja/reserved.variables.request.php
