### PR TITLE
Add working_dir to Composer Service in Docker Compose Configuration

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,7 @@ version: '3'
 services:
   composer:
     image: composer
+    working_dir: /var/www/app/
     volumes:
       - .:/var/www/app/
     environment:


### PR DESCRIPTION
### Changes Made
Added working_dir to the composer service in our docker-compose.yml file. This change allows us to execute the composer install command directly within the container without needing to manually navigate to the directory where composer.json resides.

### Background
Without a specified working_dir in our current docker-compose.yml for the composer service, developers must manually change to the directory containing composer.json to run composer install. This extra step complicates the development process, potentially becoming a barrier for new developers joining the project.

### Benefits of the Change
By specifying a working_dir, the container automatically starts in the correct directory when docker-compose up is executed, allowing direct execution of composer install. This simplification of the development process makes it easier for new developers to set up their environment and contributes to a smoother workflow.

### Verification
No side effects are anticipated with this change. The addition of working_dir only affects the operation of the composer service and does not impact other services or the overall functionality. The change has been tested in a local environment and works as expected.

### Conclusion
This adjustment enables developers to bypass unnecessary steps within the container, leading to a more efficient development process. It lowers the barrier to entry for project contributions and hopefully encourages more developers to contribute smoothly.