### PR TITLE
Fix: PHP 8.1 で FILTER_SANITIZE_MAGIC_QUOTES が使用できなくなる問題を修正

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
     name: Test
     strategy:
       matrix:
-        php-version: ['7.4']
+        php-version: ['8.1', '7.4', '5.4']
     runs-on: ubuntu-latest
     steps:
     - name: Check out source code

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Check out source code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Setup PHP ${{ matrix.php-version }}
       uses: shivammathur/setup-php@v2

--- a/src/MagicQuotesGpcEmulator.php
+++ b/src/MagicQuotesGpcEmulator.php
@@ -16,31 +16,31 @@ class MagicQuotesGpcEmulator {
     define('MagicQuotesGpcEmulatorApplied', true);
   }
 
-    private function addslashesRecursive(&$value)
-    {
-        if (is_array($value)) {
-            foreach ($value as $key => &$item) {
-                $this->addslashesRecursive($item);
-            }
-        } elseif (is_object($value)) {
-            $value = get_object_vars($value);
-            $this->addslashesRecursive($value);
-        } else {
-            $value = addslashes($value);
+  private function addslashesRecursive(&$value)
+  {
+    if (is_array($value)) {
+        foreach ($value as $key => &$item) {
+            $this->addslashesRecursive($item);
         }
+    } elseif (is_object($value)) {
+        $value = get_object_vars($value);
+        $this->addslashesRecursive($value);
+    } else {
+        $value = addslashes($value);
     }
+  }
 
-    public function isApplied() {
-        return defined('MagicQuotesGpcEmulatorApplied');
-    }
+  public function isApplied() {
+    return defined('MagicQuotesGpcEmulatorApplied');
+  }
 
-    public function isMagicQuotesGpcEnabled() {
-        if ($this->isApplied()) {
-            return true;
-        }
-        if (!function_exists('get_magic_quotes_gpc')) {
-            return false;
-        }
-        return get_magic_quotes_gpc();
+  public function isMagicQuotesGpcEnabled() {
+    if ($this->isApplied()) {
+      return true;
     }
+    if (!function_exists('get_magic_quotes_gpc')) {
+      return false;
+    }
+    return get_magic_quotes_gpc();
+  }
 }

--- a/src/MagicQuotesGpcEmulator.php
+++ b/src/MagicQuotesGpcEmulator.php
@@ -8,25 +8,39 @@ class MagicQuotesGpcEmulator {
       return;
     }
 
-    $_GET = filter_var_array($_GET, FILTER_SANITIZE_MAGIC_QUOTES);
-    $_POST = filter_var_array($_POST, FILTER_SANITIZE_MAGIC_QUOTES);
-    $_COOKIE = filter_var_array($_COOKIE, FILTER_SANITIZE_MAGIC_QUOTES);
-    $_REQUEST = filter_var_array($_REQUEST, FILTER_SANITIZE_MAGIC_QUOTES);
+    $this->addslashesRecursive($_GET);
+    $this->addslashesRecursive($_POST);
+    $this->addslashesRecursive($_COOKIE);
+    $this->addslashesRecursive($_REQUEST);
 
     define('MagicQuotesGpcEmulatorApplied', true);
   }
 
-  public function isApplied() {
-    return defined('MagicQuotesGpcEmulatorApplied');
-  }
+    private function addslashesRecursive(&$value)
+    {
+        if (is_array($value)) {
+            foreach ($value as $key => &$item) {
+                $this->addslashesRecursive($item);
+            }
+        } elseif (is_object($value)) {
+            $value = get_object_vars($value);
+            $this->addslashesRecursive($value);
+        } else {
+            $value = addslashes($value);
+        }
+    }
 
-  public function isMagicQuotesGpcEnabled() {
-    if ($this->isApplied()) {
-      return true;
+    public function isApplied() {
+        return defined('MagicQuotesGpcEmulatorApplied');
     }
-    if (!function_exists('get_magic_quotes_gpc')) {
-      return false;
+
+    public function isMagicQuotesGpcEnabled() {
+        if ($this->isApplied()) {
+            return true;
+        }
+        if (!function_exists('get_magic_quotes_gpc')) {
+            return false;
+        }
+        return get_magic_quotes_gpc();
     }
-    return get_magic_quotes_gpc();
-  }
 }

--- a/src/MagicQuotesGpcEmulator.php
+++ b/src/MagicQuotesGpcEmulator.php
@@ -22,9 +22,6 @@ class MagicQuotesGpcEmulator {
         foreach ($value as $key => &$item) {
             $this->addslashesRecursive($item);
         }
-    } elseif (is_object($value)) {
-        $value = get_object_vars($value);
-        $this->addslashesRecursive($value);
     } else {
         $value = addslashes($value);
     }

--- a/tests/MagicQuotesGpcEmulatorTest.php
+++ b/tests/MagicQuotesGpcEmulatorTest.php
@@ -3,7 +3,7 @@
 require_once './vendor/autoload.php';
 
 class MagicQuotesGpcEmulatorTest extends PHPUnit\Framework\TestCase {
-  public function setUp(): void
+  public function setUp()
   {
       parent::setUp();
       ini_set('error_reporting', E_ALL & ~ E_DEPRECATED);

--- a/tests/MagicQuotesGpcEmulatorTest.php
+++ b/tests/MagicQuotesGpcEmulatorTest.php
@@ -3,9 +3,8 @@
 require_once './vendor/autoload.php';
 
 class MagicQuotesGpcEmulatorTest extends PHPUnit\Framework\TestCase {
-  public function setUp()
+  public function initializeSuperGlobals()
   {
-      parent::setUp();
       ini_set('error_reporting', E_ALL & ~ E_DEPRECATED);
 
       $_GET = [
@@ -43,6 +42,7 @@ class MagicQuotesGpcEmulatorTest extends PHPUnit\Framework\TestCase {
   * @test
   */
   public function testBeforeApply() {
+    $this->initializeSuperGlobals();
     $emulator = new Takapi86\MagicQuotesGpcEmulator();
     $this->assertFalse($emulator->isApplied());
     $this->assertFalse($emulator->isMagicQuotesGpcEnabled());
@@ -52,6 +52,7 @@ class MagicQuotesGpcEmulatorTest extends PHPUnit\Framework\TestCase {
   * @test
   */
   public function testApply() {
+    $this->initializeSuperGlobals();
     $emulator = new Takapi86\MagicQuotesGpcEmulator();
     $emulator->apply();
 
@@ -100,6 +101,7 @@ class MagicQuotesGpcEmulatorTest extends PHPUnit\Framework\TestCase {
   * @test
   */
   public function testAfterApply() {
+    $this->initializeSuperGlobals();
     $emulator = new Takapi86\MagicQuotesGpcEmulator();
     $this->assertTrue($emulator->isApplied());
     $this->assertTrue($emulator->isMagicQuotesGpcEnabled());

--- a/tests/MagicQuotesGpcEmulatorTest.php
+++ b/tests/MagicQuotesGpcEmulatorTest.php
@@ -35,6 +35,8 @@ class MagicQuotesGpcEmulatorTest extends PHPUnit\Framework\TestCase {
         "baz" => "ba\z",
         "qux" => "qu" . chr(0) . "x",
       ];
+
+      return null;
   }
 
   /**

--- a/tests/MagicQuotesGpcEmulatorTest.php
+++ b/tests/MagicQuotesGpcEmulatorTest.php
@@ -34,8 +34,6 @@ class MagicQuotesGpcEmulatorTest extends PHPUnit\Framework\TestCase {
         "baz" => "ba\z",
         "qux" => "qu" . chr(0) . "x",
       ];
-
-      return null;
   }
 
   /**


### PR DESCRIPTION
このプルリクエストは、PHP 8.0 で FILTER_SANITIZE_MAGIC_QUOTES が使用できなくなる問題を修正するものです。
MagicQuotesGpcEmulator は、magic_quotes_gpc をエミュレートするために FILTER_SANITIZE_MAGIC_QUOTES を使用していましたが、この定数は PHP 8.0 で削除されました。

この修正では、FILTER_SANITIZE_MAGIC_QUOTES の代わりに addslashes() を使用し、さらに配列内の要素も正しくエスケープされるように、addslashes() を再帰的に適用する処理を追加しました。

これにより、MagicQuotesGpcEmulator は PHP 8.1 でも動作するようになり、magic_quotes_gpc のエミュレーション機能が維持されました。

下記の方法もありますが、PHP5.4～PHP8.1互換性を保つためこのような対応を行いました。
https://github.com/takapi86/magic-quotes-gpc-emulator/pull/6

---

またPHP5.4でもテストが通ることを確認するための対応も行っています。